### PR TITLE
feat: add `solder_file()` to flatten single Solidity file

### DIFF
--- a/solderx/fuse_file.py
+++ b/solderx/fuse_file.py
@@ -1,0 +1,149 @@
+import os
+from typing import List, Dict, Set, Tuple, Optional
+from solderx.utils import *
+
+def resolve_import_path_file(current_base_dir: str, imp: str, remappings: Optional[Dict[str, str]] = None) -> Tuple[str, str]:
+        """
+        Resolves the absolute path of an imported Solidity file.
+
+        Supports:
+        - Relative imports: import "../utils/Context.sol";
+        - Absolute imports: import "B.sol";
+        - Remapped imports: import "@oz/contracts/Ownable.sol";
+
+        Args:
+            importing_file (str): Path of the file doing the import.
+            imp (str): Import path as written in the Solidity file.
+            remappings (Optional[Dict[str, str]]): Mapping of import prefixes to actual paths.
+
+        Returns:
+            Optional[str]: Absolute path to the resolved file, or None if not found.
+        """
+        remappings = remappings or {}
+
+        # 1. Check if it's a relative path (starts with "./" or "../")
+        if imp.startswith('.') or imp.startswith('/'):
+            resolved_filepath = os.path.normpath(os.path.join(current_base_dir, imp))
+            if os.path.isfile(resolved_filepath):
+                return resolved_filepath, os.path.dirname(resolved_filepath)
+
+        # 2. Try remappings (match longest prefix)
+        longest_match = None
+        for prefix in remappings:
+            # Ensure trailing slash for matching
+            normalized_prefix = prefix if prefix.endswith('/') else prefix + '/'
+            if imp.startswith(normalized_prefix):
+                if longest_match is None or len(normalized_prefix) > len(longest_match):
+                    longest_match = normalized_prefix
+
+        if longest_match:
+            remapped_base_dir = remappings[longest_match.rstrip('/')]  # remove trailing slash if present
+            remaining_path = imp[len(longest_match):]  # strip prefix from import
+            remapped_filepath = os.path.normpath(os.path.join(remapped_base_dir, remaining_path))
+            if os.path.isfile(remapped_filepath):
+                return remapped_filepath, os.path.dirname(remapped_filepath)
+            
+
+        # 3. Fallback: Treat as local file in same directory
+        resolved_filepath = os.path.normpath(os.path.join(current_base_dir, imp))
+        if os.path.isfile(resolved_filepath):
+            return resolved_filepath,  os.path.dirname(resolved_filepath)
+
+        raise FileNotFoundError(f"Could not resolve import '{imp}' from '{current_base_dir}'")
+                    
+
+def build_imports_map_and_extract_code_file(entry_filepath: str, remappings: Dict[str, str]) -> Tuple[Dict[str, List[str]], Dict[str, List[str]], Dict[str, str]]:
+    """
+    Recursively builds an import graph from a Solidity file.
+    Supports relative and remapped imports (e.g. @openzeppelin).
+    
+    Args:
+        entry_filepath (str): Entry Solidity file (absolute or relative).
+        remappings (Dict[str, str]): Mapping from virtual prefixes to real paths.
+    
+    Returns:
+        Tuple containing:
+            - imports_path_map: actual resolved file dependencies
+            - imports_raw_map: raw import strings as seen in source
+            - file_code_map: mapping of absolute file paths to cleaned source code
+    """
+    imports_raw_map: Dict[str, List[str]] = {}
+    imports_path_map: Dict[str, List[str]] = {}
+    file_code_map: Dict[str, str] = {}
+    visited: Set[str] = set()
+
+    def resolve_and_read(path: str) -> str:
+        if not os.path.exists(path):
+            raise FileNotFoundError(f"File not found: {path}")
+        with open(path, "r", encoding="utf-8") as f:
+            return f.read()
+
+    def dfs(current_filepath: str, current_base_dir: str):
+        current_filepath = os.path.abspath(current_filepath)
+
+        if current_filepath in visited:
+            return
+        visited.add(current_filepath)
+
+        code = resolve_and_read(current_filepath)
+        imports_path, imports_raw, code = extract_and_remove_imports(code)
+
+        # Update code without imports
+        file_code_map[current_filepath] = code
+        imports_raw_map[current_filepath] = imports_raw
+
+        resolved_imports_path = []
+        for imp in imports_path:
+            resolved_imp_path, new_base_dir = resolve_import_path_file(current_base_dir, imp, remappings)
+            resolved_imports_path.append(resolved_imp_path)
+            dfs(resolved_imp_path, new_base_dir)
+        imports_path_map[current_filepath] = resolved_imports_path
+
+    abs_entry = os.path.abspath(entry_filepath)
+    dfs(abs_entry, os.path.dirname(abs_entry))
+    return imports_path_map, imports_raw_map, file_code_map
+
+
+def flatten_files(sorted_paths: List[str], file_code_map: Dict[str, str]) -> str:
+    flattened_code = []
+    cwd = os.getcwd()   # or base_dir can be manually specified if needed
+
+    for path in sorted_paths:
+        abs_path = os.path.abspath(path)
+        rel_path = os.path.relpath(abs_path, cwd)
+
+        code = file_code_map.get(abs_path)
+        if not code:
+            print(f"[warn] No content for file: {abs_path}")
+            continue
+        
+        flattened_code.append(f"// File: {rel_path}\n" + code + "\n")
+        
+    return "\n".join(flattened_code)
+
+
+def solder_file(filepath:str, remappings:dict=None, output_path:str=None, save_file:bool=True) -> str:
+    """
+    Flatten a single Solidity file by resolving its imports.
+
+    Args:
+        filepath (str): Path to the root Solidity file.
+        remappings (dict): Remappings to resolve imports.
+        output_path (str): Path to save the flattened file (if save_file is True).
+        save_file (bool, optional): Whether to save the flattened code to a file. Defaults to True.
+
+    Returns:
+        str: Soldered Flat code.
+    """
+    print(f"⚡️ Soldering File : {filepath} . . . ")
+    imports_path_map, _, file_code_map = build_imports_map_and_extract_code_file(filepath, remappings)
+    print(f"> Fusing {len(file_code_map)} Solidity file(s) (including root)")
+    sorted_paths = topological_sort(imports_path_map)
+    soldered_flat_code = normalize_spdx_license(flatten_files(sorted_paths, file_code_map))
+    if save_file:
+        if not output_path: output_path =  get_default_output_path(filepath)
+        with open(output_path, 'w') as f:
+            f.write(soldered_flat_code)
+        print(f"✅ Soldered flat file saved to: {output_path}")
+    return soldered_flat_code
+   

--- a/solderx/utils.py
+++ b/solderx/utils.py
@@ -1,0 +1,269 @@
+import re, sys, os
+from typing import List, Dict, Tuple, Optional
+from collections import Counter
+import json, toml
+
+COLORS = {
+    "B_Y": "\033[1;33m", #"BOLD_YELLOW"
+    "B_W": "\033[1;37m", #"BOLD_WHITE"
+    "B_R": "\033[1;31m", #"BOLD_RED"
+    "B_G": "\033[1;32m", #"BOLD_GREEN"
+    "RESET": "\033[0m",  #"RESET"
+}
+
+# ---- Arg Parser utils ----
+
+def parse_remappings(remappings: str = None) -> dict:
+    """
+    Parses remappings from a JSON/TOML file or inline string.
+
+    Supports:
+    - Inline format: "@alias=path,@alias2=path2"
+    - File format: Path to a JSON or TOML file containing alias-path mappings
+
+    Returns:
+        dict: A mapping of alias to import path.
+
+    Exits with error if:
+    - Duplicate aliases are found
+    - Remapping file is missing or invalid
+    - Inline format is malformed
+    """
+    if not remappings:
+        return {}
+
+    remap_dict = {}
+
+    # Helper to insert with collision check
+    def insert(alias, path):
+        if alias in remap_dict:
+            print(f"❌ Error: Duplicate remapping alias detected: '{alias}'")
+            sys.exit(1)
+        remap_dict[alias.strip()] = path.strip()
+
+    # Case: JSON/TOML file path
+    if remappings.endswith('.json') or remappings.endswith('.toml'):
+        if not os.path.isfile(remappings):
+            print(f"❌ Error: Remapping file '{remappings}' not found.")
+            sys.exit(1)
+
+        try:
+            with open(remappings, 'r') as f:
+                raw = json.load(f) if remappings.endswith('.json') else toml.load(f)
+                for alias, path in raw.items():
+                    insert(alias, path)
+
+        except Exception as e:
+            print(f"❌ Error: Failed to parse remapping file: {e}")
+            sys.exit(1)
+
+    # Case: Inline string like "@a=lib/a,@b=node_modules/b"
+    else:
+        try:
+            for pair in remappings.split(','):
+                alias, path = pair.split('=')
+                insert(alias.strip(), path.strip())
+        except ValueError:
+            print("❌ Error: Invalid remapping format. Use '@alias=path,...' or path to a json/toml file.")
+            sys.exit(1)
+
+    return remap_dict
+
+def get_default_output_path(input_path: str, ) -> str:
+    """
+    Returns the default output file path.
+
+    - For a Solidity file: saves as '<file_name>_soldered.sol'in the same file directory.
+    - For a folder: saves as '<folder_name>_soldered.sol' in the same parent directory.
+    - For Explorer: saves as  : ./<address>_<chain>_soldered.sol in the cwd.
+
+     Exits with error:
+        If the input path is neither a valid file nor a directory.
+    """
+    suffix = "soldered.sol"
+
+    if input_path.startswith("0x"):
+        filename = f"{input_path}_{suffix}"
+        return os.path.join(os.getcwd(), filename)
+    elif os.path.isfile(input_path) and input_path.endswith('.sol'):
+        base, _ = os.path.splitext(input_path)
+        return f"{base}_{suffix}"
+    elif os.path.isdir(input_path):
+        folder_name = os.path.basename(os.path.normpath(input_path))
+        parent_dir = os.path.dirname(os.path.normpath(input_path))
+        return os.path.join(parent_dir, f"{folder_name}_{suffix}")
+    else:
+        print(f"❌ Error: Invalid input path: {input_path}")
+        sys.exit(1)
+
+# ---- Soldering utils ----
+
+def is_comment_position(content: str, i: int, state: dict) -> bool:
+    """Updates comment state and returns whether current index `i` is inside a comment."""
+    if content.startswith("/*", i):
+        state["inside_block_comment"] = True
+        return True
+    elif content.startswith("*/", i):
+        state["inside_block_comment"] = False
+        return True
+    elif content.startswith("//", i):
+        state["inside_inline_comment"] = True
+        return True
+    elif content[i] == '\n':
+        if state["inside_inline_comment"]:
+            state["inside_inline_comment"] = False
+        return False
+    return state["inside_block_comment"] or state["inside_inline_comment"]
+
+
+def extract_and_remove_imports(content: str) -> Tuple[List[str], List[str], str]:
+    """
+    Extracts all import statements (including multi-line and destructured imports)
+    while skipping comments, and removes them from the code.
+    """
+    state = {
+        "inside_block_comment": False,
+        "inside_inline_comment": False,
+    }
+
+    imports_raw = []
+    semicolons = []
+    import_blocks = []
+
+    inside_module = False
+    i = 0
+    while i < len(content):
+        if inside_module:
+            i += 1
+            continue
+
+        if is_comment_position(content, i, state):
+            i += 1
+            continue
+
+        if any(content.startswith(kw, i) for kw in ['library', 'interface', 'contract']):
+            inside_module = True
+            i += 1
+            continue
+
+        if content.startswith("import", i):
+            start = i
+            while i < len(content) and content[i] != ';':
+                if is_comment_position(content, i, state):
+                    i += 1
+                    continue
+                i += 1
+            i += 1  # include the semicolon
+            raw_stmt = content[start:i]
+
+            # Strip comments from the raw import block
+            cleaned = re.sub(r'//.*', '', raw_stmt)  # remove line comments
+            cleaned = re.sub(r'/\*[\s\S]*?\*/', '', cleaned)  # remove block comments
+            cleaned = ' '.join(cleaned.split())
+            imports_raw.append(cleaned)
+            import_blocks.append((start, i))
+        else:
+            if content[i] == ';':
+                semicolons.append(i)
+            i += 1
+
+    # Reconstruct code without import blocks
+    result = []
+    last_index = 0
+    for start, end in import_blocks:
+        result.append(content[last_index:start])
+        last_index = end
+    result.append(content[last_index:])
+    code = ''.join(result)
+
+    # Extract import paths from cleaned imports
+    import_paths = []
+    for imp in imports_raw:
+        matches = re.findall(r'"([^"]+)"|\'([^\']+)\'', imp)
+        for m in matches:
+            import_paths.append(m[0] or m[1])
+
+    return import_paths, imports_raw, code
+
+
+
+
+def topological_sort(imports_map: Dict[str, List[str]]) -> List[str]:
+    """
+    Perform a topological sort on the import graph.
+
+    Given a dictionary mapping each Solidity source file to the list of its import dependencies.
+    This function returns a list of file paths sorted in topological order.
+    The resulting order ensures that a file's dependencies appear before the file itself.
+
+    Args:
+        imports_map (Dict[str, List[str]]): 
+            A mapping where each key is a file path, and the value is a list of imported file paths.
+
+    Returns:
+        List[str]: A list of file paths in dependency-resolved order (from leaves to root).
+    """
+
+    from collections import defaultdict, deque
+
+    indegree = defaultdict(int)     #stores how many files depend on each file
+    graph = defaultdict(list)       #stores the reversed dependency graph (i.e., B.sol → A.sol if A imports B)
+    all_nodes = set(imports_map.keys())
+
+    # Build the reversed graph
+    """ 'A.sol': ['B.sol', 'C.sol]
+            ==> graph['B.sol'] = ['A.sol'], indegree['A.sol'] += 1
+    """
+    for node, deps in imports_map.items():
+        for dep_path in deps:
+            # dep_path = os.path.normpath(dep)
+            graph[dep_path].append(node)
+            indegree[node] += 1
+            all_nodes.add(dep_path)
+
+    # all starting points (files with no dependencies)
+    queue = deque([n for n in all_nodes if indegree[n] == 0])
+    result = []
+
+    # Topological Sort Logic (Kahn’s Algorithm)
+    while queue:
+        node = queue.popleft()
+        result.append(node)
+
+        # Visit all files that depend on this node & update
+        for neighbor in graph[node]: 
+            indegree[neighbor] -= 1
+            if indegree[neighbor] == 0:
+                queue.append(neighbor)
+
+    if len(result) != len(all_nodes):
+        raise ValueError("Cyclic import detected !")
+
+    return result  # ordered list of files to include (from leaf to root)
+
+
+def normalize_spdx_license(content: str, spdx_override: Optional[str] = None ) -> str:
+    """
+    Removes all SPDX-License-Identifier lines and inserts either:
+    - The spdx_override SPDX if given
+    - or The most common SPDX found in all the file
+    - Nothing if no SPDX is found and none is provided
+    """
+    # Find all SPDX lines using Regex
+    spdx_pattern = r'^\s*//\s*SPDX-License-Identifier:\s*([^\s]+)\s*$'
+    matches = re.findall(spdx_pattern, content, re.MULTILINE)
+
+    # Remove all SPDX lines
+    content_wo_spdx = re.sub(spdx_pattern, '', content, flags=re.MULTILINE).strip()
+
+    # Decide what SPDX license to use
+    if spdx_override:
+        header = f"// SPDX-License-Identifier: {spdx_override}\n\n"
+    elif matches:
+        most_common = Counter(matches).most_common(1)[0][0]
+        header = f"// SPDX-License-Identifier: {most_common}\n\n"
+    else:
+        header = ""
+
+    return header + content_wo_spdx
+


### PR DESCRIPTION
This PR introduces the `solder_file()` function in `fuse_file.py`, enabling flattening of single Solidity files.

## ✨ Features Added
- Flat and nested imports

- Multiline imports and multiple imports on the same line

- SPDX license header merging

- Cyclic import detection

- Import deduplication

- Handling of empty files

- Remappings

- Relative imports within remapped paths 

- ✅ CLI integration: solderx <input.sol> -o <output.sol>